### PR TITLE
Add WooCommerce features and widgetized layout

### DIFF
--- a/hisupp/footer.php
+++ b/hisupp/footer.php
@@ -3,79 +3,19 @@
                 <div class="container">
                     <div class="row justify-content-between">
                         
+                        
                         <div class="col-xl-4 col-lg-4 col-sm-6">
-                            <div class="footer-widget mb-30">
-                                <div class="f-widget-title mb-30">
-                                   <img src="<?php echo get_template_directory_uri(); ?>/assets/img/logo/f_logo.png" alt="img">
-                                </div>
-                                <div class="footer-link">
-                                    Aenean pulvinar laoreet tellus ut tincidunt. Praesent a lectus egestas, finibus enim sit amet, mollis lorem. Sed a volutpat velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas proin vitae egestas erat.
-                                </div>
-                                <div class="footer-social  mt-30">                                    
-                                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                                    <a href="#"><i class="fab fa-twitter"></i></a>
-                                    <a href="#"><i class="fab fa-instagram"></i></a>
-                                    <a href="#"><i class="fab fa-google-plus-g"></i></a>
-                                </div>   
-                            </div>
-                        </div>
-						<div class="col-xl-2 col-lg-2 col-sm-6">
-                            <div class="footer-widget mb-30">
-                                <div class="f-widget-title">
-                                    <h2>About Us</h2>
-                                </div>
-                                <div class="footer-link">
-                                    <ul>                                        
-                                        <li><a href="#">Home</a></li>
-                                        <li><a href="#"> About Us</a></li>
-                                        <li><a href="#"> Services </a></li>
-                                        <li><a href="#"> Appoiment</a></li>
-                                        <li><a href="#">Blog </a></li>
-                                    </ul>
-                                </div>
-                            </div>
+                            <?php dynamic_sidebar( 'footer-1' ); ?>
                         </div>
                         <div class="col-xl-2 col-lg-2 col-sm-6">
-                            <div class="footer-widget mb-30">
-                                <div class="f-widget-title">
-                                    <h2>Services</h2>
-                                </div>
-                                <div class="footer-link">
-                                    <ul>
-                                        <li><a href="#">FAQ</a></li>
-                                        <li><a href="#">Support</a></li>
-                                        <li><a href="#">Privercy</a></li>
-                                        <li><a href="#">Term & Conditions</a></li>
-                                    </ul>
-                                </div>
-                            </div>
-                        </div>  
-                        <div class="col-xl-4 col-lg-4 col-sm-6">
-                            <div class="footer-widget mb-30">
-                                <div class="f-contact">
-                                    <ul>
-                                    <li>
-                                        <i class="icon fal fa-phone"></i>
-                                        <span>1800-121-3637<br>+91-7052-101-786</span>
-                                    </li>
-                                   <li><i class="icon fal fa-envelope"></i>
-                                        <span>
-                                            <a href="mailto:info@example.com">info@example.com</a>
-                                       <br>
-                                       <a href="mailto:help@example.com">help@example.com</a>
-                                       </span>
-                                    </li>
-                                    <li>
-                                        <i class="icon fal fa-map-marker-check"></i>
-                                        <span>1247/Plot No. 39, 15th Phase, LHB Colony, Kanpur</span>
-                                    </li>
-                                    
-                                </ul>
-                                    
-                                    </div>
-                            </div>
+                            <?php dynamic_sidebar( 'footer-2' ); ?>
                         </div>
-                        
+                        <div class="col-xl-2 col-lg-2 col-sm-6">
+                            <?php dynamic_sidebar( 'footer-3' ); ?>
+                        </div>
+                        <div class="col-xl-4 col-lg-4 col-sm-6">
+                            <?php dynamic_sidebar( 'footer-4' ); ?>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -90,27 +30,6 @@
                 </div>
             </div>
         </footer>
-		<!-- JS here -->
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/vendor/modernizr-3.5.0.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/vendor/jquery-1.12.4.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/popper.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/bootstrap.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/one-page-nav-min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/slick.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/ajax-form.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/paroller.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/wow.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/js_isotope.pkgd.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/imagesloaded.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/parallax.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/jquery.waypoints.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/jquery.counterup.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/jquery.scrollUp.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/jquery.meanmenu.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/parallax-scroll.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/jquery.magnific-popup.min.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/element-in-view.js"></script>
-        <script src="<?php echo get_template_directory_uri(); ?>/assets/js/main.js"></script>
 <?php wp_footer(); ?>
 </body>
 </html>

--- a/hisupp/functions.php
+++ b/hisupp/functions.php
@@ -37,4 +37,49 @@ function hisupp_theme_scripts() {
     wp_enqueue_script('element-in-view', "$template_uri/assets/js/element-in-view.js", array('jquery'), null, true);
     wp_enqueue_script('main-js', "$template_uri/assets/js/main.js", array('jquery'), null, true);
 }
+
 add_action('wp_enqueue_scripts', 'hisupp_theme_scripts');
+
+function hisupp_theme_setup() {
+    add_theme_support( 'title-tag' );
+    add_theme_support( 'post-thumbnails' );
+    add_theme_support( 'post-formats', array( 'aside', 'gallery', 'link', 'image', 'quote', 'status', 'video', 'audio', 'chat' ) );
+
+    // WooCommerce support
+    add_theme_support( 'woocommerce', array(
+        'thumbnail_image_width' => 300,
+        'single_image_width'    => 600,
+    ) );
+    add_theme_support( 'wc-product-gallery-zoom' );
+    add_theme_support( 'wc-product-gallery-lightbox' );
+    add_theme_support( 'wc-product-gallery-slider' );
+
+    register_nav_menus( array(
+        'primary' => __( 'Primary Menu', 'hisupp' ),
+        'footer'  => __( 'Footer Menu', 'hisupp' ),
+    ) );
+}
+add_action( 'after_setup_theme', 'hisupp_theme_setup' );
+
+function hisupp_widgets_init() {
+    register_sidebar( array(
+        'name'          => __( 'Sidebar', 'hisupp' ),
+        'id'            => 'sidebar-1',
+        'before_widget' => '<div id="%1$s" class="widget %2$s">',
+        'after_widget'  => '</div>',
+        'before_title'  => '<h3 class="widget-title">',
+        'after_title'   => '</h3>',
+    ) );
+
+    for ( $i = 1; $i <= 4; $i++ ) {
+        register_sidebar( array(
+            'name'          => sprintf( __( 'Footer %d', 'hisupp' ), $i ),
+            'id'            => 'footer-' . $i,
+            'before_widget' => '<div id="%1$s" class="widget %2$s">',
+            'after_widget'  => '</div>',
+            'before_title'  => '<h3 class="widget-title">',
+            'after_title'   => '</h3>',
+        ) );
+    }
+}
+add_action( 'widgets_init', 'hisupp_widgets_init' );

--- a/hisupp/header.php
+++ b/hisupp/header.php
@@ -55,36 +55,14 @@
                               
                                 <div class="main-menu text-right text-xl-right">
                                     <nav id="mobile-menu">
-                                         <ul>
-                                            <li class="has-sub">
-												<a href="<?php echo home_url( "/" ); ?>">Home</a>
-											</li>
-                                            <li><a href="#ingredient">Ingredient</a></li>
-                                             <li class="has-sub"><a href="#supplement">Supplement</a>
-                                                 <ul>													
-													<li><a href="<?php echo home_url( "/shop" ); ?>">Shop</a></li>
-													<li><a href="<?php echo home_url( "/shop-details" ); ?>">Shop Details</a>
-												</li>
-												</ul>
-                                             </li>
-                                             <li><a href="#pricing">Pricing</a></li>
-                                            <li class="has-sub"> 
-                                              <a href="#introduction">Introduction</a>
-                                                
-                                            </li>
-                                           
-											<li class="has-sub"> 
-                                                <a href="#blog">Blog</a>
-                                                <ul>													
-													<li><a href="<?php echo home_url( "/blog" ); ?>">Blog</a></li>
-													<li><a href="<?php echo home_url( "/blog-details" ); ?>">Blog Details</a></li>
-												</ul>
-                                            </li>
-                                                                        
-										
-                                            <li><a href="#contact">Contact</a></li>                                               
-                                             <li><a href="#" class="btn ss-btn">Purchase Now</a></li>                                
-                                        </ul>
+                                        <?php
+                                        wp_nav_menu( array(
+                                            'theme_location' => 'primary',
+                                            'container'      => false,
+                                            'menu_class'     => '',
+                                            'fallback_cb'    => '__return_false',
+                                        ) );
+                                        ?>
                                     </nav>
                                 </div>
                             </div>   

--- a/hisupp/index.php
+++ b/hisupp/index.php
@@ -20,4 +20,5 @@
         <p><?php esc_html_e( 'No posts found.', 'hisupp' ); ?></p>
     <?php endif; ?>
 </main><!-- #main -->
+<?php get_sidebar(); ?>
 <?php get_footer(); ?>

--- a/hisupp/sidebar.php
+++ b/hisupp/sidebar.php
@@ -1,0 +1,5 @@
+<?php if ( is_active_sidebar( 'sidebar-1' ) ) : ?>
+    <aside id="secondary" class="widget-area">
+        <?php dynamic_sidebar( 'sidebar-1' ); ?>
+    </aside>
+<?php endif; ?>

--- a/hisupp/single.php
+++ b/hisupp/single.php
@@ -28,4 +28,5 @@
         <?php endwhile; endif; ?>
     </div>
 </main>
+<?php get_sidebar(); ?>
 <?php get_footer(); ?>

--- a/hisupp/woocommerce/archive-product.php
+++ b/hisupp/woocommerce/archive-product.php
@@ -6,6 +6,7 @@ get_header();
         <?php do_action( 'woocommerce_before_main_content' ); ?>
 
         <?php if ( woocommerce_product_loop() ) : ?>
+            <div class="row">
             <?php woocommerce_product_loop_start(); ?>
 
             <?php if ( wc_get_loop_prop( 'total' ) ) : ?>
@@ -15,6 +16,7 @@ get_header();
             <?php endif; ?>
 
             <?php woocommerce_product_loop_end(); ?>
+            </div>
 
             <?php do_action( 'woocommerce_after_shop_loop' ); ?>
         <?php else : ?>

--- a/hisupp/woocommerce/content-product.php
+++ b/hisupp/woocommerce/content-product.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * The template for displaying product content within loops
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+global $product;
+if ( empty( $product ) || ! $product->is_visible() ) {
+    return;
+}
+?>
+<li <?php wc_product_class( 'col-md-3 col-sm-6 mb-40', $product ); ?> >
+    <div class="product">
+        <div class="product__img">
+            <a href="<?php the_permalink(); ?>">
+                <?php woocommerce_template_loop_product_thumbnail(); ?>
+            </a>
+            <div class="product-action text-center">
+                <?php woocommerce_template_loop_add_to_cart(); ?>
+            </div>
+        </div>
+        <div class="product__content text-center pt-30">
+            <h4 class="pro-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h4>
+            <?php
+            do_action( 'woocommerce_after_shop_loop_item_title' );
+            ?>
+        </div>
+    </div>
+</li>

--- a/hisupp/woocommerce/content-single-product-inner.php
+++ b/hisupp/woocommerce/content-single-product-inner.php
@@ -1,0 +1,21 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div id="product-<?php the_ID(); ?>" <?php wc_product_class( 'row', $product ); ?> >
+    <div class="col-md-6 mb-30">
+        <?php
+        do_action( 'woocommerce_before_single_product_summary' );
+        ?>
+    </div>
+    <div class="col-md-6 mb-30">
+        <div class="summary entry-summary">
+            <?php
+            do_action( 'woocommerce_single_product_summary' );
+            ?>
+        </div>
+    </div>
+</div>
+<?php do_action( 'woocommerce_after_single_product_summary' ); ?>
+

--- a/hisupp/woocommerce/content-single-product.php
+++ b/hisupp/woocommerce/content-single-product.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * The Template for displaying all single products
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+get_header( 'shop' );
+?>
+<main class="single-product-page pt-100 pb-100">
+    <div class="container">
+        <?php
+        while ( have_posts() ) :
+            the_post();
+            wc_get_template_part( 'content', 'single-product-inner' );
+        endwhile;
+        ?>
+    </div>
+</main>
+<?php
+get_footer( 'shop' );
+?>


### PR DESCRIPTION
## Summary
- register menus, widgets and WooCommerce theme support
- replace header menu with `wp_nav_menu`
- replace footer HTML with widget areas
- add sidebar template and include in posts
- tweak WooCommerce templates for shop and single products

## Testing
- `php -l hisupp/functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8f90f4a08323bff679a9c5beb2ba